### PR TITLE
Allow transmitting from a different timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Options:
         -s <service>          : Service; one of 'DCF77', 'WWVB', 'JJY40', 'JJY60', 'MSF'
         -r <minutes>          : Run for limited number of minutes. (default: no limit)
         -t 'YYYY-MM-DD HH:MM' : Transmit the given local time (default: now)
+        -z <minutes>          : Transmit the time offset from local (default: 0 minutes)
         -v                    : Verbose.
         -n                    : Dryrun, only showing modulation envelope.
         -h                    : This help.

--- a/txtempus.cc
+++ b/txtempus.cc
@@ -138,6 +138,8 @@ int usage(const char *msg, const char *progname) {
           "(default: no limit)\n"  // in truth: a couple thousand years...
           "\t-t 'YYYY-MM-DD HH:MM' : Transmit the given local time "
           "(default: now)\n"
+          "\t-z <minutes>          : Transmit the time offset from local "
+          "(default: 0 minutes)\n"
           "\t-v                    : Verbose.\n"
           "\t-n                    : Dryrun, only showing modulation "
           "envelope.\n"
@@ -152,9 +154,10 @@ int main(int argc, char *argv[]) {
   const time_t now = TruncateTo(time(NULL), 60);  // Time signals: full minute
   const char *service = "";
   time_t chosen_time = now;
+  int zone_offset = 0;
   int ttl = INT_MAX;
   int opt;
-  while ((opt = getopt(argc, argv, "t:r:vs:hn")) != -1) {
+  while ((opt = getopt(argc, argv, "t:z:r:vs:hn")) != -1) {
     switch (opt) {
     case 'v':
       verbose = true;
@@ -162,6 +165,9 @@ int main(int argc, char *argv[]) {
     case 't':
       chosen_time = ParseLocalTime(optarg);
       if (chosen_time <= 0) return usage("Invalid time string\n", argv[0]);
+      break;
+    case 'z':
+      zone_offset = atoi(optarg);
       break;
     case 'r':
       ttl = atoi(optarg);
@@ -179,6 +185,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  chosen_time += zone_offset * 60;
   const int time_offset = chosen_time - now;
 
   TimeSignalSource *time_source = CreateTimeSourceFromName(service);


### PR DESCRIPTION
If I'm in the timezone GMT+2, DCF77 is located in GMT+1,
and my watch is able to account for the difference, allow transmitting
the signal one hour retard.