### PR TITLE
Fix memory leak and minor refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,16 @@ PROJECT(txtempus
         LANGUAGES C CXX)
 
 include(GNUInstallDirs)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 ADD_DEFINITIONS(-Wall -O3)
 
 set(CMAKE_INSTALL_PREFIX /usr)
 
 set(SRC_FILES 
     src/txtempus.cc
-    src/dcf77-source.cc 
-    src/wwvb-source.cc 
-    src/jjy-source.cc 
+    src/dcf77-source.cc
+    src/wwvb-source.cc
+    src/jjy-source.cc
     src/msf-source.cc
     src/hardware-control.cc)
 
@@ -21,13 +21,13 @@ set(INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include)
 set(PLATFORM_DEPENDENCIES "")
 
 # select the platform
-set(SUPPORTED_PLATFORMS rpi jetson) 
+set(SUPPORTED_PLATFORMS rpi jetson)
 set(PLATFORM "rpi" CACHE STRING "Platform")
 
 if(NOT ${PLATFORM} IN_LIST SUPPORTED_PLATFORMS)
     string(REPLACE ";"  ", " SUPPORTED_PLATFORM_LIST "${SUPPORTED_PLATFORMS}")
     message(FATAL_ERROR "'${PLATFORM}' is not a supported platform.\nSupported platforms: [${SUPPORTED_PLATFORM_LIST}]")
-endif() 
+endif()
 
 message(STATUS "Platform: ${PLATFORM}")
 

--- a/src/txtempus.cc
+++ b/src/txtempus.cc
@@ -137,7 +137,7 @@ int usage(const char *msg, const char *progname) {
 
 int main(int argc, char *argv[]) {
   const time_t now = TruncateTo(time(NULL), 60);  // Time signals: full minute
-  const char *service = "";
+  std::string service{};
   time_t chosen_time = now;
   int zone_offset = 0;
   int ttl = INT_MAX;
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
       ttl = atoi(optarg);
       break;
     case 's':
-      service = strdup(optarg);
+      service = optarg;
       break;
     case 'n':
       dryrun = true;
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
   chosen_time += zone_offset * 60;
   const int time_offset = chosen_time - now;
 
-  auto time_source = CreateTimeSourceFromName(service);
+  auto time_source = CreateTimeSourceFromName(service.c_str());
   if (!time_source)
     return usage("Please choose a service name with -s option\n", argv[0]);
 

--- a/src/txtempus.cc
+++ b/src/txtempus.cc
@@ -102,15 +102,15 @@ void PrintModulationChart(const TimeSignalSource::SecondModulation &mod) {
 
 std::unique_ptr<TimeSignalSource> CreateTimeSourceFromName(const char *n) {
   if (strcasecmp(n, "DCF77") == 0)
-    return std::unique_ptr<TimeSignalSource>{new DCF77TimeSignalSource()};
+    return std::make_unique<DCF77TimeSignalSource>();
   if (strcasecmp(n, "WWVB") == 0)
-    return std::unique_ptr<TimeSignalSource>{new WWVBTimeSignalSource()};
+    return std::make_unique<WWVBTimeSignalSource>();
   if (strcasecmp(n, "JJY40") == 0)
-    return std::unique_ptr<TimeSignalSource>{new JJY40TimeSignalSource()};
+    return std::make_unique<JJY40TimeSignalSource>();
   if (strcasecmp(n, "JJY60") == 0)
-    return std::unique_ptr<TimeSignalSource>{new JJY60TimeSignalSource()};
+    return std::make_unique<JJY60TimeSignalSource>();
   if (strcasecmp(n, "MSF") == 0)
-    return std::unique_ptr<TimeSignalSource>{new MSFTimeSignalSource()};
+    return std::make_unique<MSFTimeSignalSource>();
   return nullptr;
 }
 

--- a/src/txtempus.cc
+++ b/src/txtempus.cc
@@ -137,7 +137,7 @@ int usage(const char *msg, const char *progname) {
 
 int main(int argc, char *argv[]) {
   const time_t now = TruncateTo(time(NULL), 60);  // Time signals: full minute
-  std::string service{};
+  std::unique_ptr<TimeSignalSource> time_source{};
   time_t chosen_time = now;
   int zone_offset = 0;
   int ttl = INT_MAX;
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
       ttl = atoi(optarg);
       break;
     case 's':
-      service = optarg;
+      time_source = CreateTimeSourceFromName(optarg);
       break;
     case 'n':
       dryrun = true;
@@ -173,7 +173,6 @@ int main(int argc, char *argv[]) {
   chosen_time += zone_offset * 60;
   const int time_offset = chosen_time - now;
 
-  auto time_source = CreateTimeSourceFromName(service.c_str());
   if (!time_source)
     return usage("Please choose a service name with -s option\n", argv[0]);
 

--- a/src/txtempus.cc
+++ b/src/txtempus.cc
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include <string>
+#include <memory>
 
 #include "hardware-control.h"
 #include "time-signal-source.h"
@@ -99,17 +100,17 @@ void PrintModulationChart(const TimeSignalSource::SecondModulation &mod) {
   fprintf(stderr, "]\n");
 }
 
-TimeSignalSource *CreateTimeSourceFromName(const char *n) {
+std::unique_ptr<TimeSignalSource> CreateTimeSourceFromName(const char *n) {
   if (strcasecmp(n, "DCF77") == 0)
-    return new DCF77TimeSignalSource();
+    return std::unique_ptr<TimeSignalSource>{new DCF77TimeSignalSource()};
   if (strcasecmp(n, "WWVB") == 0)
-    return new WWVBTimeSignalSource();
+    return std::unique_ptr<TimeSignalSource>{new WWVBTimeSignalSource()};
   if (strcasecmp(n, "JJY40") == 0)
-    return new JJY40TimeSignalSource();
+    return std::unique_ptr<TimeSignalSource>{new JJY40TimeSignalSource()};
   if (strcasecmp(n, "JJY60") == 0)
-    return new JJY60TimeSignalSource();
+    return std::unique_ptr<TimeSignalSource>{new JJY60TimeSignalSource()};
   if (strcasecmp(n, "MSF") == 0)
-    return new MSFTimeSignalSource();
+    return std::unique_ptr<TimeSignalSource>{new MSFTimeSignalSource()};
   return nullptr;
 }
 
@@ -172,7 +173,7 @@ int main(int argc, char *argv[]) {
   chosen_time += zone_offset * 60;
   const int time_offset = chosen_time - now;
 
-  TimeSignalSource *time_source = CreateTimeSourceFromName(service);
+  auto time_source = CreateTimeSourceFromName(service);
   if (!time_source)
     return usage("Please choose a service name with -s option\n", argv[0]);
 
@@ -224,5 +225,4 @@ int main(int argc, char *argv[]) {
   }
 
   if (!dryrun) hw.StopClock();
-  delete time_source;
 }


### PR DESCRIPTION
- there was no `free` for the `strdup` in the code 
  - [description on strdup from cppreference: ](https://en.cppreference.com/w/c/experimental/dynamic/strdup) `The returned pointer must be passed to free to avoid a memory leak.`
  - replaced `strdup` with `std::string` (fix memory leak)
  
- minor refactoring 
  - changed time_source type to `std::unque_ptr` (remove potential memory leak risk)


