### PR TITLE
Add version option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,14 @@ ADD_DEFINITIONS(-Wall -O3)
 
 set(CMAKE_INSTALL_PREFIX /usr)
 
-set(SRC_FILES 
+set(SRC_FILES
     src/txtempus.cc
     src/dcf77-source.cc
     src/wwvb-source.cc
     src/jjy-source.cc
     src/msf-source.cc
-    src/hardware-control.cc)
+    src/hardware-control.cc
+    src/user-input.cc)
 
 set(INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include)
 set(PLATFORM_DEPENDENCIES "")

--- a/include/user-input.h
+++ b/include/user-input.h
@@ -1,0 +1,39 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Part of txtempus, a LF time signal transmitter.
+// Copyright (C) 2018 Henner Zeller <h.zeller@acm.org>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef USER_INPUT_H
+#define USER_INPUT_H
+
+#include <time.h>
+#include <string>
+
+class UserInput {
+public:
+  UserInput(int argc, char *argv[]);
+  std::string chosen_time;
+  std::string service;
+  int zone_offset = 0;
+  int ttl;
+  bool verbose = false;
+  bool dryrun = false;
+  bool show_help = false;
+
+private:
+  void Parse(int argc, char *argv[]);
+};
+
+#endif

--- a/include/user-input.h
+++ b/include/user-input.h
@@ -31,6 +31,7 @@ public:
   bool verbose = false;
   bool dryrun = false;
   bool show_help = false;
+  bool show_version = false;
 
 private:
   void Parse(int argc, char *argv[]);

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,23 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Part of txtempus, a LF time signal transmitter.
+// Copyright (C) 2018 Henner Zeller <h.zeller@acm.org>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VERSION_H
+#define VERSION_H
+
+constexpr auto VERSION = "txtempus 1.0.0.0";
+
+#endif

--- a/src/txtempus.cc
+++ b/src/txtempus.cc
@@ -19,7 +19,6 @@
 // as DCF77, WWVB, ... to be run on the Raspberry Pi.
 // Make sure to stay within the regulation limits of HF transmissions!
 
-#include <getopt.h>
 #include <limits.h>
 #include <sched.h>
 #include <signal.h>
@@ -29,6 +28,7 @@
 #include <time.h>
 #include <strings.h>
 #include <string.h>
+#include <iostream>
 
 #include <string>
 #include <memory>
@@ -129,9 +129,15 @@ int usage(const char *msg, const char *progname) {
           "\t-v                    : Verbose.\n"
           "\t-n                    : Dryrun, only showing modulation "
           "envelope.\n"
-          "\t-h                    : This help.\n",
+          "\t-h                    : This help \n"
+          "\t--version             : Show version info.\n",
           msg, progname);
   return 1;
+}
+
+void ShowVersionInfo()
+{
+  std::cout << "txtempus 1.0.0.0" << std::endl;
 }
 
 }  // end anonymous namespace
@@ -139,6 +145,12 @@ int usage(const char *msg, const char *progname) {
 int main(int argc, char *argv[]) {
   const time_t now = TruncateTo(time(NULL), 60);  // Time signals: full minute
   UserInput input(argc, argv);
+
+  if(input.show_version)
+  {
+    ShowVersionInfo();
+    return 0;
+  }
 
   time_t chosen_time = now;
   if(input.chosen_time != "")

--- a/src/txtempus.cc
+++ b/src/txtempus.cc
@@ -36,6 +36,7 @@
 #include "hardware-control.h"
 #include "time-signal-source.h"
 #include "user-input.h"
+#include "version.h"
 
 static bool verbose = false;
 static bool dryrun = false;
@@ -137,7 +138,7 @@ int usage(const char *msg, const char *progname) {
 
 void ShowVersionInfo()
 {
-  std::cout << "txtempus 1.0.0.0" << std::endl;
+  std::cout << VERSION << std::endl;
 }
 
 }  // end anonymous namespace

--- a/src/user-input.cc
+++ b/src/user-input.cc
@@ -30,15 +30,33 @@ UserInput::UserInput(int argc, char *argv[])
       ttl(INT_MAX),
       verbose(false),
       dryrun(false),
-      show_help(false) {
+      show_help(false),
+      show_version(false) {
     Parse(argc, argv);
 }
 
 
 void UserInput::Parse(int argc, char *argv[]) {
+  int option_flag = 0;
+  struct option long_options[] =
+  {
+      {"version", no_argument, &option_flag, 1},
+      {nullptr, 0, nullptr, 0}
+  };
+
+  constexpr auto short_options = "t:z:r:vs:hn";
+
+  int option_index = 0;
   int opt{};
-  while ((opt = getopt(argc, argv, "t:z:r:vs:hn")) != -1) {
+
+  while ((opt = getopt_long(argc, argv, short_options, long_options, &option_index)) != -1) {
     switch (opt) {
+    case 0:   // long options
+      if (option_flag == 1)
+        show_version = true;
+      break;
+
+    // short options
     case 'v':
       verbose = true;
       break;

--- a/src/user-input.cc
+++ b/src/user-input.cc
@@ -1,0 +1,67 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// This is txtempus, a LF time signal transmitter.
+// Copyright (C) 2018 Henner Zeller <h.zeller@acm.org>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Time-signal simulating transmitter, supporting various types such
+// as DCF77, WWVB, ... to be run on the Raspberry Pi.
+// Make sure to stay within the regulation limits of HF transmissions!
+
+#include "user-input.h"
+#include <limits.h>
+#include <getopt.h>
+
+UserInput::UserInput(int argc, char *argv[])
+    : chosen_time(""),
+      service{},
+      zone_offset(0),
+      ttl(INT_MAX),
+      verbose(false),
+      dryrun(false),
+      show_help(false) {
+    Parse(argc, argv);
+}
+
+
+void UserInput::Parse(int argc, char *argv[]) {
+  int opt{};
+  while ((opt = getopt(argc, argv, "t:z:r:vs:hn")) != -1) {
+    switch (opt) {
+    case 'v':
+      verbose = true;
+      break;
+    case 't':
+      chosen_time = optarg;
+      break;
+    case 'z':
+      zone_offset = atoi(optarg);
+      break;
+    case 'r':
+      ttl = atoi(optarg);
+      break;
+    case 's':
+      service = optarg;
+      break;
+    case 'n':
+      dryrun = true;
+      verbose = true;
+      ttl = 1;
+      break;
+    default:
+      show_help = true;
+      return;
+    }
+  }
+}


### PR DESCRIPTION
Added `--version` option to the txtempus.  
  
Usage: 
```shell
txtempus --version
```
Output:
```shell
txtempus 1.0.0.0
```


Added  hard-coded version info for now, but is possible to generate the `version.h` on build using the version info in the `CMakeLists.txt` in the future.